### PR TITLE
Format csproj file and fix *.Build.props file path

### DIFF
--- a/OpenRA.Mods.Mobius/OpenRA.Mods.Mobius.csproj
+++ b/OpenRA.Mods.Mobius/OpenRA.Mods.Mobius.csproj
@@ -1,17 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <EngineRootPath>../engine</EngineRootPath>
-  </PropertyGroup>
-  <Import Project="../engine/Directory.Build.props" />
-  <ItemGroup>
-    <ProjectReference Include="$(EngineRootPath)/OpenRA.Game/OpenRA.Game.csproj">
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="$(EngineRootPath)/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj">
-      <Private>False</Private>
-    </ProjectReference>
-    <ProjectReference Include="$(EngineRootPath)/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj">
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
+
+	<PropertyGroup>
+		<EngineRootPath>../engine</EngineRootPath>
+	</PropertyGroup>
+
+	<Import Project="$(EngineRootPath)/Directory.Build.props" />
+
+	<ItemGroup>
+		<ProjectReference Include="$(EngineRootPath)/OpenRA.Game/OpenRA.Game.csproj">
+			<Private>False</Private>
+		</ProjectReference>
+
+		<ProjectReference Include="$(EngineRootPath)/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj">
+			<Private>False</Private>
+		</ProjectReference>
+
+		<ProjectReference Include="$(EngineRootPath)/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj">
+			<Private>False</Private>
+		</ProjectReference>
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
I noticed the `Directory.Build.props` wasn't the best it could be, and somehow ended up formatting the entire file to ~~look better~~ match the ModSDK Example mod/RA2 one.